### PR TITLE
Fixed #15 menu routing

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -24,15 +24,22 @@
         </v-list-item>
 
         <v-divider></v-divider>
-
-        <v-list-item @click="route(item.title)" v-for="item in items" :key="item.title" link>
-          <v-list-item-icon>
-            <v-icon>{{ item.icon }}</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>{{ item.title }}</v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
+        <router-link
+          :to="{ name: item.title }"
+          v-for="item in items"
+          :key="item.title"
+          tag="div"
+          class="mb-1"
+        >
+          <v-list-item link>
+            <v-list-item-icon>
+              <v-icon>{{ item.icon }}</v-icon>
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>{{ item.title }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </router-link>
       </v-list>
       <template v-slot:append>
         <div v-if="!mini" class="pa-2">
@@ -77,7 +84,7 @@ export default class Register extends Vue {
 
   // METHODS
   route(name: string) {
-    this.$router.push(name);
+    this.$router.push({ name });
   }
   async logout() {
     const loggedOut = await this.$store.dispatch("auth/logout");
@@ -86,7 +93,7 @@ export default class Register extends Vue {
       //   path: this.$route.path
       // });
       // window.location.assign(r.href);
-      this.route("login");
+      this.route("Login");
     }
   }
   parseInitials(name: string | null) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -22,7 +22,7 @@ const routes: Array<RouteConfig> = [
   },
   {
     path: "/settings",
-    name: "Setting",
+    name: "Settings",
     component: Settings,
     meta: {
       requiresAuth: true


### PR DESCRIPTION
- Error was caused by duplicate routing (routing to current route)
- Changed menu items to use router-link, which by default ignores this error
- Other possibilities included checking from and to routes before routing
- changed router to use route "name" instead of "path" property