### PR TITLE
Fixed #36 Github API token authorization error

### DIFF
--- a/src/integrations/github.ts
+++ b/src/integrations/github.ts
@@ -34,7 +34,7 @@ const createJWT = () => {
   const token = jwt.sign({}, APPLICATIONKEY, {
     algorithm: "RS256",
     issuer: APPLICATIONID,
-    expiresIn: 10 * 60 // ten minutes, maximum expiration time per GitHub docs
+    expiresIn: 10 * 60 - 30 // ten minutes, maximum expiration time per GitHub docs
   });
   return token;
 };


### PR DESCRIPTION
- It seems that maxing out the expiration time runs into rounding errors that make Github think the token is invalid.
- Built in some buffer (30s) to account for this sensitivity
- Referenced https://github.com/probot/probot/issues/942