### PR TITLE
Filtering out editable packages/authors in Admin

### DIFF
--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -39,7 +39,8 @@ export const actions: ActionTree<IAuthState, IRootState> = {
             name: docData?.name,
             roles: docData?.roles,
             uid: user.uid,
-            config: docData?.config
+            config: docData?.config,
+            githubId: docData?.githubId
           };
           context.commit("setUser", _user);
         });

--- a/src/store/authors.ts
+++ b/src/store/authors.ts
@@ -19,6 +19,12 @@ export const getters: GetterTree<IAuthorsState, IRootState> = {
   getAuthorNameById: state => (authorId: string): string => {
     const author = state.authors.find(author => author.id === authorId);
     return author ? author.name : "Unknown";
+  },
+  getAuthorAdmins: state => (authorId: string): number[] => {
+    const author = state.authors.find(author => author.id === authorId);
+    if (author && author.sourceConfig.github) {
+      return author.sourceConfig.github.admins;
+    } else return [];
   }
 };
 

--- a/src/store/packages.ts
+++ b/src/store/packages.ts
@@ -15,7 +15,11 @@ export const state: IPackagesState = {
   isPackageListenerSet: false
 };
 
-export const getters: GetterTree<IPackagesState, IRootState> = {};
+export const getters: GetterTree<IPackagesState, IRootState> = {
+  getPackageAdmins: (state, getters, rootState, rootGetters) => (pkg: Package): number[] => {
+    return rootGetters["authors/getAuthorAdmins"](pkg.authorId);
+  }
+};
 
 export const mutations: MutationTree<IPackagesState> = {
   setPackages(state, payload: Package[]) {

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -155,11 +155,6 @@ export default class Admin extends Vue {
     { text: "", value: "edit" }
   ];
 
-  // authors = [
-  //   { name: "Voyansi", id: 1, sources: ["GitHub"], packageCount: 14 },
-  //   { name: "John Smith (me)", id: 2, sources: ["GitHub", "URL"], packageCount: 3 }
-  // ];
-
   enterprises = [
     { name: "Salesforce", id: 1, memberCount: 257, packageCount: 6 },
     { name: "Voyansi", id: 2, memberCount: 144, packageCount: 11 },
@@ -169,11 +164,17 @@ export default class Admin extends Vue {
 
   // COMPUTED PROPERTIES
   get packages(): Package[] {
-    return this.$store.state.packages.packages;
+    return this.$store.state.packages.packages.filter((pkg: Package) => {
+      const packageAdmins = this.$store.getters["packages/getPackageAdmins"](pkg);
+      return packageAdmins.includes(this.$store.state.auth.user.githubId);
+    });
   }
 
   get authors() {
-    return this.$store.state.authors.authors;
+    return this.$store.state.authors.authors.filter((author: Author) => {
+      const authorAdmins = this.$store.getters["authors/getAuthorAdmins"](author.id);
+      return authorAdmins.includes(this.$store.state.auth.user.githubId);
+    });
   }
 
   // METHOD


### PR DESCRIPTION
- Added filters that compare an authenticated user's Github Id against a list of admins for a given package or author, thereby limiting which objects will be visible in the Admin panel